### PR TITLE
Enable Swagger without API key

### DIFF
--- a/Middleware/ApiKeyMiddleware.cs
+++ b/Middleware/ApiKeyMiddleware.cs
@@ -11,12 +11,20 @@ namespace ReservationSystem2022.Middleware
 
         public async Task InvokeAsync(HttpContext context)
         {
+            // Allow swagger requests without an API key so the documentation UI works.
+            if (context.Request.Path.StartsWithSegments("/swagger"))
+            {
+                await _next(context);
+                return;
+            }
+
             if (!context.Request.Headers.TryGetValue(APIKEYNAME, out var extractedApiKey))
             {
                 context.Response.StatusCode = 401;
                 await context.Response.WriteAsync("Api key missing");
                 return;
             }
+
             var appSettings = context.RequestServices.GetRequiredService<IConfiguration>();
             var apiKey = appSettings.GetValue<string>(APIKEYNAME);
             if (!apiKey.Equals(extractedApiKey))
@@ -25,6 +33,7 @@ namespace ReservationSystem2022.Middleware
                 await context.Response.WriteAsync("Unauthorized client");
                 return;
             }
+
             await _next(context);
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -5,6 +5,7 @@ using ReservationSystem2022.Middleware;
 using ReservationSystem2022.Models;
 using ReservationSystem2022.Repositories;
 using ReservationSystem2022.Services;
+using System.Collections.Generic;
 using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -41,6 +42,32 @@ builder.Services.AddSwaggerGen(options =>
             Url = new Uri("https://example.com/license")
         }
     });
+
+    // Add API key support to swagger
+    options.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme
+    {
+        Description = "API Key required to access the endpoints. Example: `INNINLNNINIB`",
+        Type = SecuritySchemeType.ApiKey,
+        Name = "ApiKey",
+        In = ParameterLocation.Header,
+        Scheme = "ApiKeyScheme"
+    });
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "ApiKey"
+                }
+            },
+            new List<string>()
+        }
+    });
+
     // using System.Reflection;
     var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     //options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));


### PR DESCRIPTION
## Summary
- allow the Swagger UI and docs to bypass API key middleware
- add Swagger security definition for sending `ApiKey` header

## Testing
- `dotnet build --nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be8e23c88832fa539ca5c8a58a0bd