### PR TITLE
Remove user auth and clean item services

### DIFF
--- a/Models/Item.cs
+++ b/Models/Item.cs
@@ -7,7 +7,7 @@ namespace ReservationSystem2022.Models
         public long Id { get; set; }
         public String Name { get; set; }
         public String? Description { get; set; }
-        public virtual User? Owner { get; set; }
+        public string? Owner { get; set; }
         public virtual List<Image> Images { get; set; }
         public long accessCount { get; set; } //sisäinen kenttä 
 
@@ -21,7 +21,7 @@ namespace ReservationSystem2022.Models
         public String Name { get; set; }
         public String? Description { get; set; }
         [Required]
-        public String Owner { get; set; }
+        public string Owner { get; set; }
 
         public virtual List<ImageDTO>? Images { get; set; }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using ReservationSystem2022.Middleware;
@@ -6,8 +5,6 @@ using ReservationSystem2022.Models;
 using ReservationSystem2022.Repositories;
 using ReservationSystem2022.Services;
 using System.Collections.Generic;
-using ReservationSystem2022.Repositories;
-using ReservationSystem2022.Services;
 using System.Text.Json.Serialization;
 using System.Reflection;
 
@@ -20,14 +17,8 @@ builder.Services.AddControllers().AddJsonOptions(options =>
 {
     options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
 });
-builder.Services.AddAuthentication("BasicAuthentication").AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("BasicAuthentication", null);
 builder.Services.AddScoped<IItemService, ItemService>();
 builder.Services.AddScoped<IItemRepository, ItemRepository>();
-builder.Services.AddScoped<IUserService, UserService>();
-builder.Services.AddScoped<IUserRepository, UserRepository>();
-builder.Services.AddScoped<IReservationService, ReservationService>();
-builder.Services.AddScoped<IReservationRepository, ReservationRepository>();
-builder.Services.AddScoped<IUserAuthenticationService, UserAuthenticationService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 
@@ -102,7 +93,6 @@ app.UseHttpsRedirection();
 
 app.UseMiddleware<ApiKeyMiddleware>();
 
-app.UseAuthentication();
 
 app.UseAuthorization();
 

--- a/Repositories/IItemRepository.cs
+++ b/Repositories/IItemRepository.cs
@@ -6,7 +6,6 @@ namespace ReservationSystem2022.Repositories
     {
         public Task<Item> GetItemAsync(long id);
         public Task<IEnumerable<Item>> GetItemsAsync();
-        public Task<IEnumerable<Item>> GetItemsAsync(User user);
         public Task<IEnumerable<Item>> QueryItems(String query);
         public Task<Item> AddItemAsync(Item item);
         public Task<Item> UpdateItemAsync(Item item);

--- a/Repositories/ItemRepository.cs
+++ b/Repositories/ItemRepository.cs
@@ -69,14 +69,9 @@ namespace ReservationSystem2022.Repositories
             return await _context.Items.Include(i => i.Images).ToListAsync();
         }
 
-        public async Task<IEnumerable<Item>> GetItemsAsync(User user)
-        {
-            return await _context.Items.Include(i => i.Owner).Where(x => x.Owner == user).ToListAsync();
-        }
-
         public async Task<IEnumerable<Item>> QueryItems(string query)
         {
-            return await _context.Items.Include(i => i.Owner).Where(x => x.Name.Contains(query)).ToListAsync();
+            return await _context.Items.Where(x => x.Name.Contains(query)).Include(i => i.Images).ToListAsync();
         }
 
         public async Task<Item> UpdateItemAsync(Item item) 

--- a/Services/IItemService.cs
+++ b/Services/IItemService.cs
@@ -7,7 +7,6 @@ namespace ReservationSystem2022.Services
         public Task<ItemDTO> CreateItemAsync(ItemDTO dto);
         public Task<ItemDTO> GetItemAsync(long id);
         public Task<IEnumerable<ItemDTO>> GetItemsAsync();
-        public Task<IEnumerable<ItemDTO>> GetItemsAsync(string username);
         public Task<IEnumerable<ItemDTO>> QueryItemsAsync(string query);
         public Task<ItemDTO> UpdateItemAsync(ItemDTO item);
         public Task<bool> DeleteItemAsync(long id);

--- a/Services/ItemService.cs
+++ b/Services/ItemService.cs
@@ -1,5 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using ReservationSystem2022.Controllers;
 using ReservationSystem2022.Models;
 using ReservationSystem2022.Repositories;
 
@@ -8,16 +6,14 @@ namespace ReservationSystem2022.Services
     public class ItemService : IItemService
     {
         private readonly IItemRepository _repository;
-        private readonly IUserRepository _userRepository;
 
-        public ItemService(IItemRepository repository, IUserRepository userRepository)
+        public ItemService(IItemRepository repository)
         {
             _repository = repository;
-            _userRepository = userRepository;
         }
         public async Task<ItemDTO> CreateItemAsync(ItemDTO dto)
         {
-            Item newItem = await DTOToItem(dto);
+            Item newItem = DTOToItem(dto);
             await _repository.AddItemAsync(newItem);
             return ItemToDTO(newItem);
         }
@@ -102,34 +98,13 @@ namespace ReservationSystem2022.Services
             return itemDTOs;
         }
 
-        public async Task<IEnumerable<ItemDTO>> GetItemsAsync(string username)
-        {
-            User owner = await _userRepository.GetUserAsync(username);
-            if (owner == null)
-            {
-                return null;
-            }
-            IEnumerable<Item> items = await _repository.GetItemsAsync(owner);
-            List<ItemDTO> itemDTOs = new List<ItemDTO>();
-            foreach (Item i in items)
-            {
-                itemDTOs.Add(ItemToDTO(i));
-            }
-            return itemDTOs;
-        }
-        private async Task<Item> DTOToItem(ItemDTO dto)
+
+        private Item DTOToItem(ItemDTO dto)
         {
             Item newItem = new Item();
             newItem.Name = dto.Name;
             newItem.Description = dto.Description;
-
-            //Hae omistaja kannasta
-            User owner = await _userRepository.GetUserAsync(dto.Owner);
-
-            if (owner != null)
-            {
-                newItem.Owner = owner;
-            }
+            newItem.Owner = dto.Owner;
             if (dto.Images != null)
             {
                 newItem.Images = new List<Image>();
@@ -159,10 +134,7 @@ namespace ReservationSystem2022.Services
                 }
             }
 
-            if (item.Owner != null)
-            {
-                dto.Owner = item.Owner.UserName;
-            }
+            dto.Owner = item.Owner;
 
             return dto;
         }


### PR DESCRIPTION
## Summary
- drop authentication services and user dependencies from Program.cs
- simplify `ItemService` to remove user lookups
- update `Item` model to store owner name directly
- adjust repository and service interfaces accordingly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf529ca78832f8f2bfd66bcb0879f